### PR TITLE
Feature/support strings in setters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /test/dummy/tmp/
 /test/dummy/dummy_test
 /Gemfile.lock
+/coverage

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ user1 = User.create!(permissions: %i[read write execute])
 user2 = User.create!(permissions: %i[read write])
 user3 = User.create!(permissions: %i[read])
 
-# .where(permissions: ...) will generate an `IN` query, returning all records that have *any* 
+# .where(permissions: ...) will generate an `IN` query, returning all records that have *any*
 # of those permissions.
 User.where(permissions: %i[read write]) # => [user1, user2, user3]
 
@@ -101,6 +101,17 @@ lol stop
 
 ## Contributing
 Make an issue / PR and we'll see.
+
+### Development
+
+```bash
+$ cd enummer
+$ bundle install
+$ cd test/dummy
+$ RAILS_ENV=test DATABASE_URL=sqlite3:dummy_test rails db:setup
+$ cd ../..
+$ RAILS_ENV=test DATABASE_URL=sqlite3:dummy_test bin/test
+```
 
 ## Alternatives
 - [flag_shih_tzu](https://github.com/pboling/flag_shih_tzu)

--- a/lib/enummer/enummer_type.rb
+++ b/lib/enummer/enummer_type.rb
@@ -22,7 +22,7 @@ module Enummer
     def serialize(value)
       return unless value
 
-      Array.wrap(value).sum { |value_name| @bit_pairs.fetch(value_name, 0) }
+      Array.wrap(value).sum { |value_name| @bit_pairs.fetch(value_name.to_sym, 0) }
     end
 
     # @param [Numeric] value Numeric representation of values

--- a/test/enummer_test.rb
+++ b/test/enummer_test.rb
@@ -65,6 +65,12 @@ class EnummerTest < ActiveSupport::TestCase
     assert_equal %i[read execute], @user1.permissions
   end
 
+  test "setting the attribute with strings adds the values" do
+    @user3.update(permissions: ["read", "write"])
+
+    assert_equal %i[read write], @user3.permissions
+  end
+
   test "using a bang method properly updates the persisted field" do
     @user3.read!
     @user3.reload


### PR DESCRIPTION
Related to https://github.com/shkm/enummer/issues/13

When dealing with forms, values will be received as strings. This pull request adds a simple `.to_sym` method when serialising the array.

I also added a little hint about how to run tests locally