### PR TITLE
Support passing strings in with_ scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@
 /test/dummy/log/*.log
 /test/dummy/tmp/
 /test/dummy/dummy_test
+/test/dummy/*-wal
+/test/dummy/*-shm
 /Gemfile.lock
 /coverage

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "standard"
 
 group :test do
   gem "pg"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.4"
   gem "mysql2"
   gem "simplecov", require: false
   gem 'simplecov-cobertura', require: false

--- a/lib/enummer/extension.rb
+++ b/lib/enummer/extension.rb
@@ -26,7 +26,7 @@ module Enummer
 
     def _enummer_build_with_scope(attribute_name, value_names)
       scope "with_#{attribute_name}", lambda { |desired|
-        expected = Array.wrap(desired).sum(0) { |value| 1 << value_names.index(value) }
+        expected = Array.wrap(desired).sum(0) { |value| 1 << value_names.index(value.to_sym) }
 
         where("#{attribute_name} & :expected = :expected", expected: expected)
       }

--- a/test/enummer_test.rb
+++ b/test/enummer_test.rb
@@ -31,6 +31,8 @@ class EnummerTest < ActiveSupport::TestCase
 
   test "with_ scope returns users with all of those bits set" do
     assert_equal [@user1], User.with_permissions(%i[execute read write])
+    assert_equal [@user1], User.with_permissions(%w[execute read write])
+    assert_equal [@user1, @user2], User.with_permissions(['read', :write])
   end
 
   test "not scopes return users without those bits set" do


### PR DESCRIPTION
Currently the `with_` scope only supports passing symbols, raising an unassuming `TypeError` if a string passed. This just takes a similar approach to https://github.com/shkm/enummer/pull/14 and supports passing in strings as well.

I've also fixed a sqlite3 testing issue that I encountered locally but seems to also be happening on [CI](https://github.com/shkm/enummer/actions/runs/10210505070/job/28250230460).

Thanks for your work on this useful gem!