### PR TITLE
Allow initializing enummer with hash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ group :test do
   gem "sqlite3", "~> 1.4"
   gem "mysql2"
   gem "simplecov", require: false
-  gem 'simplecov-cobertura', require: false
+  gem "simplecov-cobertura", require: false
 end

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ Now set up enummer with the available values in your model:
 enummer permissions: %i[read write execute]
 ```
 
+Similar to `enum`, enummer can also be initialized with a hash, where the numeric index represents the position of the bit that maps to the flag:
+
+``` ruby
+enummer permissions: {
+  read: 0,
+  write: 1,
+  execute: 2
+}
+```
+
+This makes it easier to add/remove entries without worrying about migrating historical data.
+
 ### Scopes
 
 Scopes will now be provided for `<option>` and `not_<option>`.

--- a/enummer.gemspec
+++ b/enummer.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = ">= 2.7"
   spec.add_dependency "rails", ">= 7.0.0"
 end

--- a/lib/enummer/enummer_type.rb
+++ b/lib/enummer/enummer_type.rb
@@ -4,17 +4,16 @@ require "active_record/type"
 
 module Enummer
   class EnummerType < ::ActiveRecord::Type::Value
-    # @param [Array<Symbol>] value_names list of all possible values for this type
-    def initialize(value_names:)
-      @value_names = value_names
-      @bit_pairs = determine_bit_pairs(value_names)
+    # @param [Array<Symbol>] values hash with bit-value pairs for all possible values for this type
+    def initialize(values:)
+      @values = values
     end
 
     # @return Symbol Representation of this type
     # @example
     #   :enummer[read|write|execute]
     def type
-      "enummer[#{@value_names.join("|")}]".to_sym
+      :"enummer[#{@values.keys.join("|")}]"
     end
 
     # @param [Symbol|Array<Symbol>] value Current value represented as one or more symbols
@@ -22,7 +21,7 @@ module Enummer
     def serialize(value)
       return unless value
 
-      Array.wrap(value).sum { |value_name| @bit_pairs.fetch(value_name.to_sym, 0) }
+      Array.wrap(value).sum { |value_name| @values.fetch(value_name.to_sym, 0) }
     end
 
     # @param [Numeric] value Numeric representation of values
@@ -31,19 +30,11 @@ module Enummer
       return [] unless value
       return [] if value.to_i.zero?
 
-      @bit_pairs.each_with_object([]) do |(pair_name, pair_value), value_names|
+      @values.each_with_object([]) do |(pair_name, pair_value), value_names|
         next if (value & pair_value).zero?
 
         value_names << pair_name
       end
-    end
-
-    private
-
-    def determine_bit_pairs(value_names)
-      value_names.map.with_index do |name, shift|
-        [name, 1 << shift]
-      end.to_h
     end
   end
 end

--- a/lib/enummer/enummer_type.rb
+++ b/lib/enummer/enummer_type.rb
@@ -21,7 +21,7 @@ module Enummer
     def serialize(value)
       return unless value
 
-      Array.wrap(value).sum { |value_name| @values.fetch(value_name.to_sym, 0) }
+      Array.wrap(value).sum { |value_name| @values.fetch(value_name, 0) }
     end
 
     # @param [Numeric] value Numeric representation of values
@@ -35,6 +35,12 @@ module Enummer
 
         value_names << pair_name
       end
+    end
+
+    # @param [Array<Symbol>] value Current value represented as one or more symbols or strings
+    # @return [Array<Symbol>] Current value represented as symbols
+    def cast(value)
+      Array.wrap(value).map(&:to_sym)
     end
   end
 end

--- a/lib/enummer/extension.rb
+++ b/lib/enummer/extension.rb
@@ -37,8 +37,8 @@ module Enummer
       values.each do |name, bit|
         method_name = _enummer_method_name(attribute_name, name, options)
 
-        define_method("#{method_name}?") { self[attribute_name].include?(name) }
-        define_method("#{method_name}=") do |new_value|
+        define_method(:"#{method_name}?") { self[attribute_name].include?(name) }
+        define_method(:"#{method_name}=") do |new_value|
           if ActiveModel::Type::Boolean.new.cast(new_value)
             self[attribute_name] += [name]
           else
@@ -46,7 +46,7 @@ module Enummer
           end
           self[attribute_name].uniq!
         end
-        define_method("#{method_name}!") do
+        define_method(:"#{method_name}!") do
           update(attribute_name => self[attribute_name] + [name])
         end
 

--- a/lib/tasks/enummer_tasks.rake
+++ b/lib/tasks/enummer_tasks.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # desc "Explaining what the task does"
 # task :enummer do
 #   # Task goes here

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -5,10 +5,10 @@ class User < ApplicationRecord
 
   enummer facial_features: %i[nose mouth eyes], _prefix: true
   enummer diets: {
-            alcohol: 1,
-            cigarettes: 0,
-            greens: 2
-          }, _prefix: "consumes"
+    alcohol: 1,
+    cigarettes: 0,
+    greens: 2
+  }, _prefix: "consumes"
 
   enummer transport: %i[car truck submarine], _suffix: true
   enummer home: %i[box apartment house], _suffix: "home"

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -4,7 +4,11 @@ class User < ApplicationRecord
   enummer permissions: %i[read write execute]
 
   enummer facial_features: %i[nose mouth eyes], _prefix: true
-  enummer diets: %i[cigarettes alcohol greens], _prefix: "consumes"
+  enummer diets: {
+            alcohol: 1,
+            cigarettes: 0,
+            greens: 2
+          }, _prefix: "consumes"
 
   enummer transport: %i[car truck submarine], _suffix: true
   enummer home: %i[box apartment house], _suffix: "home"

--- a/test/dummy/config/initializers/content_security_policy.rb
+++ b/test/dummy/config/initializers/content_security_policy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy

--- a/test/dummy/config/initializers/inflections.rb
+++ b/test/dummy/config/initializers/inflections.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/test/dummy/config/initializers/permissions_policy.rb
+++ b/test/dummy/config/initializers/permissions_policy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Define an application-wide HTTP permissions policy. For further
 # information see https://developers.google.com/web/updates/2018/06/feature-policy
 #

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2022_01_30_163927) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,5 +21,4 @@ ActiveRecord::Schema.define(version: 2022_01_30_163927) do
     t.integer "transport"
     t.integer "home"
   end
-
 end

--- a/test/enummer_test.rb
+++ b/test/enummer_test.rb
@@ -32,7 +32,7 @@ class EnummerTest < ActiveSupport::TestCase
   test "with_ scope returns users with all of those bits set" do
     assert_equal [@user1], User.with_permissions(%i[execute read write])
     assert_equal [@user1], User.with_permissions(%w[execute read write])
-    assert_equal [@user1, @user2], User.with_permissions(['read', :write])
+    assert_equal [@user1, @user2], User.with_permissions(["read", :write])
     assert_equal [@user1, @user2], User.with_diets(%i[cigarettes])
   end
 

--- a/test/enummer_test.rb
+++ b/test/enummer_test.rb
@@ -9,7 +9,7 @@ class EnummerTest < ActiveSupport::TestCase
       diets: %i[cigarettes alcohol],
       transport: %i[submarine],
       home: %i[box])
-    @user2 = User.new(permissions: %i[read write])
+    @user2 = User.new(permissions: %i[read write], diets: %i[cigarettes])
     @user3 = User.new(permissions: %i[execute])
 
     [@user1, @user2, @user3].map { |user| user.save && user.reload }
@@ -33,6 +33,7 @@ class EnummerTest < ActiveSupport::TestCase
     assert_equal [@user1], User.with_permissions(%i[execute read write])
     assert_equal [@user1], User.with_permissions(%w[execute read write])
     assert_equal [@user1, @user2], User.with_permissions(['read', :write])
+    assert_equal [@user1, @user2], User.with_diets(%i[cigarettes])
   end
 
   test "not scopes return users without those bits set" do
@@ -106,7 +107,7 @@ class EnummerTest < ActiveSupport::TestCase
   end
 
   test "recognizes boolean params" do
-    @user1.update!(ActionController::Parameters.new({"consumes_cigarettes"=>"false"}).permit(:consumes_cigarettes))
+    @user1.update!(ActionController::Parameters.new({"consumes_cigarettes" => "false"}).permit(:consumes_cigarettes))
     refute @user1.consumes_cigarettes?
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start do
   enable_coverage :branch
-  add_filter '/test/dummy/'
+  add_filter "/test/dummy/"
 
-  if ENV['CI']
-    require 'simplecov-cobertura'
+  if ENV["CI"]
+    require "simplecov-cobertura"
     SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
   end
 end
 
-  # Configure Rails Environment
+# Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
 require_relative "../test/dummy/config/environment"


### PR DESCRIPTION
Similar to the Rails `enum` behavior, allow initializing an `enummer` with a hash where the values correspond to the indices of the bits that map to the flag.

This is a more robust and backwards-compatible approach to enums, as the developer doesn't have to worry about migrating historical data if an enum value is removed.

I also took the liberty of running `standardrb` on the entire project, seeing as the gem is part of the development dependencies.

Thanks again for this useful gem!